### PR TITLE
added LXD_SOCKET override to wrapper service

### DIFF
--- a/lxd/lxd-containers.service
+++ b/lxd/lxd-containers.service
@@ -5,6 +5,7 @@ After=lxd.socket lxd.service
 Requires=lxd.socket
 
 [Service]
+Environment=LXD_SOCKET=/run/lxd.socket
 Type=oneshot
 ExecStart=/usr/bin/lxd activateifneeded
 ExecStop=/usr/libexec/lxd/shutdown


### PR DESCRIPTION
* fixes #5 - wrapper service start needs the same env override that the main `lxd.service` has to talk to the right socket.